### PR TITLE
AWS Audit Manager Showcase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ override.tf.json
 
 # Ignore transient lock info files created by terraform apply
 .terraform.tfstate.lock.info
-
+.terraform.lock.hcl
 # Include override files you do wish to add to version control using negated pattern
 # !example_override.tf
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
 # aws-audit-manager-showcase
-Showcase for AWS Audit Manager configuration
+This project provides a Terraform module for developing assessments in AWS Audit Manager. The module simplifies the creation and management of audit assessments, ensuring compliance with best practices and governance standards.
+
+## Project Structure
+
+
+```
+├── modules
+│   └── audit_manager_assessments
+│       ├── main.tf
+│       ├── variables.tf
+│       └── outputs.tf
+├── stacks
+│   ├── management_account
+│   │   ├── main.tf
+│   │   └── variables.tf
+│   └── audit_account
+│       ├── main.tf
+│       └── variables.tf
+└── README.md
+```
+
+### Modules
+
+#### `audit_manager_assessments`
+
+This module allows you to create and manage assessments in AWS Audit Manager. It includes capabilities to:
+
+- Define assessment frameworks and controls.
+- Automate evidence collection.
+- Generate reports for compliance and audit readiness.
+
+### Stacks
+
+#### Management Account
+
+The management_account stack is responsible for deploying resources in the management account. It creates the KMS Customer Key to be used for AWS Audit Manager, which is also shared with the Audit Account. Finally, it sets up AWS Audit Manager, delegating administration to the Audit Account and selecting the created KMS Key.
+
+- **Location**: `stacks/management_account/`
+- **Usage**: To deploy this stack, navigate to the `management_account` directory, execute `terraform init` to initialize the provider, followed by `terraform apply` to deploy the resources.
+
+#### Audit Account
+
+The `audit_account` stack is designed for deploying resources specific to the audit account. It utilizes the `audit_manager_assessments` module to establish the assessments tailored for auditing purposes.
+
+- **Location**: `stacks/audit_account/`
+- **Usage**: To deploy this stack, navigate to the `audit_account` directory, execute `terraform init`, and then run `terraform apply` to provision the required resources.
+
+### Requirements
+
+- Terraform 1.8
+- AWS credentials configured in your environment
+- IAM permissions to manage AWS Audit Manager resources
+
+### Getting Started
+
+1. Clone the repository.
+2. Navigate to either the `management_account` or `audit_account` stack directory.
+3. Execute the following commands:
+
+```bash
+terraform init
+terraform apply
+```
+
+# Contributing
+Feel free to submit issues or pull requests to improve the module or stacks. Any contributions are welcome!

--- a/modules/aws_audit_manager_assessment/README.md
+++ b/modules/aws_audit_manager_assessment/README.md
@@ -1,0 +1,56 @@
+# Audit Manager Assessments
+This module enables the automation and management of audit assessment processes in AWS through AWS Audit Manager. This module facilitates the configuration of customized audit assessments, ensuring compliance with regulations and best practices. It includes features to define assessment criteria, automate evidence collection, and generate detailed reports on the status of audits, thereby optimizing risk management and continuous improvement within the organization.
+
+```hcl
+module "assessment" {
+  source          = "./modules/aws_audit_manager_assessment"
+  assessment_name = "my_assessment"
+  bucket_name     = "my-bucket-for-audit-manager-assessment"
+  owner_roles     = ["arn:aws:iam::123456789123:role/owner_group"]
+  framework_id    = "Statement on Standards for Attestations Engagement (SSAE) No. 18, Service Organizations Controls (SOC) Report 2"
+  target_accounts = ["123456789123"]
+}
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.82.2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.82.2 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_auditmanager_assessment.assessment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/auditmanager_assessment) | resource |
+| [aws_auditmanager_framework.framework](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/auditmanager_framework) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_assessment_name"></a> [assessment\_name](#input\_assessment\_name) | The name of the assessment. | `string` | n/a | yes |
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the S3 bucket to store the assessment reports. | `string` | n/a | yes |
+| <a name="input_framework_id"></a> [framework\_id](#input\_framework\_id) | The id of the framework to use for the assessment. | `string` | n/a | yes |
+| <a name="input_framework_type"></a> [framework\_type](#input\_framework\_type) | The type of the framework to use for the assessment. | `string` | `"Standard"` | no |
+| <a name="input_owner_roles"></a> [owner\_roles](#input\_owner\_roles) | The IAM roles to associate with the assessment. | `list(string)` | n/a | yes |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | The prefix to apply to the bucket name. | `string` | `"demo"` | no |
+| <a name="input_target_accounts"></a> [target\_accounts](#input\_target\_accounts) | The AWS account IDs to assess. | `list(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | arn of the assessment object |
+| <a name="output_id"></a> [id](#output\_id) | id of the assessment object |
+| <a name="output_owner_roles"></a> [owner\_roles](#output\_owner\_roles) | roles of the assessment object |

--- a/modules/aws_audit_manager_assessment/main.tf
+++ b/modules/aws_audit_manager_assessment/main.tf
@@ -1,0 +1,34 @@
+data "aws_auditmanager_framework" "framework" {
+  name           = var.framework_id
+  framework_type = var.framework_type
+}
+
+resource "aws_auditmanager_assessment" "assessment" {
+  name = var.assessment_name
+
+  assessment_reports_destination {
+    destination      = "s3://${var.bucket_name}"
+    destination_type = "S3"
+  }
+
+  framework_id = data.aws_auditmanager_framework.framework.id
+
+  dynamic "roles" {
+    for_each = var.owner_roles
+    iterator = role
+    content {
+      role_arn  = role.value
+      role_type = "PROCESS_OWNER"
+    }
+  }
+  
+  dynamic "scope" {
+    for_each = var.target_accounts
+    iterator = account_id
+    content {
+      aws_accounts {
+        id = account_id.value
+      }
+    }
+  }
+}

--- a/modules/aws_audit_manager_assessment/outputs.tf
+++ b/modules/aws_audit_manager_assessment/outputs.tf
@@ -1,0 +1,14 @@
+output "arn" {
+  description = "arn of the assessment object"
+  value = aws_auditmanager_assessment.assessment.arn
+}
+
+output "id" {
+  description = "id of the assessment object"
+  value = aws_auditmanager_assessment.assessment.id
+}
+
+output "owner_roles" {
+  description = "roles of the assessment object"
+  value = aws_auditmanager_assessment.assessment.roles_all
+}

--- a/modules/aws_audit_manager_assessment/providers.tf
+++ b/modules/aws_audit_manager_assessment/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = ">= 5.82.2"
+    }
+  }
+}

--- a/modules/aws_audit_manager_assessment/variables.tf
+++ b/modules/aws_audit_manager_assessment/variables.tf
@@ -1,0 +1,36 @@
+variable "assessment_name" {
+  description = "The name of the assessment."
+  type        = string
+}
+
+variable "prefix" {
+  description = "The prefix to apply to the bucket name."
+  type        = string
+  default    = "demo"
+}
+
+variable "bucket_name" {
+  description = "The name of the S3 bucket to store the assessment reports."
+  type        = string
+}
+
+variable "owner_roles" {
+  description = "The IAM roles to associate with the assessment."
+  type        = list(string)
+}
+
+variable "framework_id" {
+  description = "The id of the framework to use for the assessment."
+  type        = string
+}
+
+variable "framework_type"{
+  description = "The type of the framework to use for the assessment."
+  type        = string
+  default     = "Standard"
+}
+
+variable "target_accounts" {
+  description = "The AWS account IDs to assess."
+  type        = list(string)
+} 

--- a/stacks/audit_account/data.tf
+++ b/stacks/audit_account/data.tf
@@ -1,0 +1,1 @@
+data "aws_region" "current" {}

--- a/stacks/audit_account/main.tf
+++ b/stacks/audit_account/main.tf
@@ -1,0 +1,8 @@
+module "assessment" {
+  source          = "../../modules/aws_audit_manager_assessment"
+  assessment_name = var.assessment_name
+  bucket_name     = aws_s3_bucket.audit_manager_report.bucket
+  owner_roles     = var.owner_roles
+  framework_id    = var.framework_id
+  target_accounts = var.target_accounts
+}

--- a/stacks/audit_account/outputs.tf
+++ b/stacks/audit_account/outputs.tf
@@ -1,0 +1,9 @@
+output "soc_assessment_arn" {
+  value = module.assessment.arn
+}
+output "soc_assessment_id" {
+  value = module.assessment.id
+}
+output "soc_assessment_owner_roles" {
+  value = module.assessment.owner_roles
+}

--- a/stacks/audit_account/provider.tf
+++ b/stacks/audit_account/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.82.2"
+    }
+  }
+  required_version = ">= 1.8"
+}

--- a/stacks/audit_account/s3.tf
+++ b/stacks/audit_account/s3.tf
@@ -1,0 +1,48 @@
+resource "aws_s3_bucket" "audit_manager_report" {
+  bucket        = "${var.prefix}-audit-manager-report-${data.aws_region.current.name}"
+  force_destroy = true
+
+  tags = {
+    Name        = "${var.prefix}-audit-manager-report-${data.aws_region.current.name}"
+    Environment = "Sandbox"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "kms_sse" {
+  bucket = aws_s3_bucket.audit_manager_report.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = var.kms_key_id
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "public_access_block" {
+  bucket = aws_s3_bucket.audit_manager_report.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_acl" "acl" {
+  bucket = aws_s3_bucket.audit_manager_report.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "versioning" {
+  bucket = aws_s3_bucket.audit_manager_report.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_logging" "logging" {
+  bucket = aws_s3_bucket.audit_manager_report.id
+
+  target_bucket = var.logging_bucket_name
+  target_prefix = "log/"
+}

--- a/stacks/audit_account/variables.tf
+++ b/stacks/audit_account/variables.tf
@@ -1,0 +1,35 @@
+variable "prefix" {
+  description = "Prefix to be used for all resources"
+  type        = string
+}
+
+variable "assessment_name" {
+  description = "Name of the assessment"
+  type        = string
+}
+
+variable "kms_key_id" {
+  description = "KMS key to be used for all resources"
+  type        = string
+}
+
+variable "target_accounts" {
+  description = "List of account IDs to be assessed"
+  type        = list(string)
+}
+
+variable "framework_id" {
+  description = "The ID of the framework to be used for the assessment"
+  type        = string
+  default     = "Statement on Standards for Attestations Engagement (SSAE) No. 18, Service Organizations Controls (SOC) Report 2"
+}
+
+variable "owner_roles" {
+  description = "List of ARNs of the roles that own the resources to be assessed"
+  type        = list(string)
+}
+
+variable "logging_bucket_name" {
+  description = "Name of the bucket to store logs"
+  type        = string
+}

--- a/stacks/management_account/kms.tf
+++ b/stacks/management_account/kms.tf
@@ -1,0 +1,17 @@
+module "kms_key_audit_manager" {
+  source = "git@github.com:terraform-aws-modules/terraform-aws-kms.git?ref=v3.1.1"
+
+  deletion_window_in_days = 7
+  description             = "KMS Key to encrypt data for AWS Audit Manager"
+  enable_key_rotation     = true
+  is_enabled              = true
+  key_usage               = "ENCRYPT_DECRYPT"
+  multi_region            = false
+
+  # Policy
+  enable_default_policy = true
+  key_administrators    = var.kms_key_admins
+  key_users             = var.kms_key_users
+  aliases               = ["alias/aws/auditmanager/key"]
+  tags                  = var.tags
+}

--- a/stacks/management_account/main.tf
+++ b/stacks/management_account/main.tf
@@ -1,0 +1,6 @@
+resource "aws_auditmanager_account_registration" "registration" {
+  delegated_admin_account = var.delegated_admin_account
+  kms_key                 = module.kms_key_audit_manager.key_arn
+  deregister_on_destroy   = true
+}
+

--- a/stacks/management_account/outputs.tf
+++ b/stacks/management_account/outputs.tf
@@ -1,0 +1,3 @@
+output "kms_key_audit_manager" {
+  value = module.kms_key_audit_manager.key_arn
+}

--- a/stacks/management_account/provider.tf
+++ b/stacks/management_account/provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.82.2"
+    }
+  }
+  required_version = ">= 1.8"
+}

--- a/stacks/management_account/variables.tf
+++ b/stacks/management_account/variables.tf
@@ -1,0 +1,22 @@
+variable "delegated_admin_account" {
+  type        = string
+  description = "The AWS account ID of the delegated admin account."
+}
+
+variable "kms_key_admins" {
+  type        = list(string)
+  description = "The list of IAM users or roles that should be granted administrative access to the KMS key."
+}
+
+variable "kms_key_users" {
+  type        = list(string)
+  description = "The list of IAM users or roles that should be granted access to the KMS key for encryption and decryption."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to apply to the resources."
+  default = {
+    "ManagedBy" = "Terraform"
+  }
+}


### PR DESCRIPTION
It includes an example to deploy AWS Audit Manager in an AWS Organization. This project contains stacks that isolate the deployment to the `management` and `audit` accounts.